### PR TITLE
fix: Se ajusta funcion Plan ordenada por rubro para retornar json vac…

### DIFF
--- a/models/registro_plan_adquisicion.go
+++ b/models/registro_plan_adquisicion.go
@@ -39,7 +39,7 @@ func ObtenerRegistroPlanAdquisicionByIDplan(planAdquisicionID string) (registroP
 			delete(RegistroPlanAdquisicion[rubroindex], "PlanAdquisicionesId")
 			fuentes, errFuente := SeparaFuentes(RegistroPlanAdquisicion[rubroindex]["RubroId"])
 			if errFuente != nil {
-				return nil, errFuente
+				return RegistroPlanAdquisicion[rubroindex], nil
 			}
 			newfuente := stringInSlice(fuentes, unicos)
 			if !newfuente {


### PR DESCRIPTION
…io si no hay registro plan adquisicion

Se ajusta función que trae los registros plan adquisición ordenador por rubro para que retorne un json vacío y no error en caso de que no exista plan de adquisición.

```Json
{
  "Type": "OK",
  "Code": "200",
  "Body": {}
}
```