### PR TITLE
feat: Se adiciona Endpoint para ver versiones de mongo de un plna de …

### DIFF
--- a/.env
+++ b/.env
@@ -6,4 +6,3 @@ API_BASE_DIR=github.com/udistrital
 PLAN_ADQUISICIONES_CRUD_URL=http://192.168.0.12:8080/v1/ #Si se corre en local usar localhost: / Si se corre en ambiente dockerizado usar IP de la PC
 #PLAN_CUENTAS_MONGO_CRUD_URL=https://autenticacion.portaloas.udistrital.edu.co/apioas/plan_cuentas_mongo_crud/v1/   
 CATALOGO_ELEMENTOS_ARKA_URL=https://autenticacion.portaloas.udistrital.edu.co/apioas/catalogo_elementos_crud/v1/
-  

--- a/controllers/plan_adquisicion.go
+++ b/controllers/plan_adquisicion.go
@@ -16,6 +16,7 @@ type Plan_adquisicionController struct {
 func (c *Plan_adquisicionController) URLMapping() {
 	c.Mapping("Post", c.Post)
 	c.Mapping("Put", c.Put)
+	c.Mapping("GetOne", c.GetOne)
 
 }
 
@@ -89,6 +90,36 @@ func (c *Plan_adquisicionController) Put() {
 		c.Ctx.Output.SetStatus(400)
 	}
 
+	c.Data["json"] = alertErr
+	c.ServeJSON()
+
+}
+
+// GetOne Función para obterner la version del plan de adquision almacenadas en mongo
+// @Title GetOne
+// @Description get Plan_adquisicionController by id
+// @Param	id		path 	string	true		"Id de un  plan de adquisicion"
+// @Success 200 {object} models.Plan_adquisicion
+// @Failure 403 :id is empty
+// @router /versiones/:id [get]
+func (c *Plan_adquisicionController) GetOne() {
+
+	planAdquisicionID := c.Ctx.Input.Param(":id")
+	var alertErr models.Alert
+	alertas := append([]interface{}{"Response:"})
+	RegistroPlanAdquisicion, errRegistroPlanAdquisicion := models.ObtenerVersionesMongoByID(planAdquisicionID)
+
+	if RegistroPlanAdquisicion != nil {
+		alertErr.Type = "OK"
+		alertErr.Code = "200"
+		alertErr.Body = RegistroPlanAdquisicion
+	} else {
+		alertErr.Type = "error"
+		alertErr.Code = "404"
+		alertas = append(alertas, errRegistroPlanAdquisicion)
+		alertErr.Body = alertas
+		c.Ctx.Output.SetStatus(404)
+	}
 	c.Data["json"] = alertErr
 	c.ServeJSON()
 

--- a/models/plan_adquisicion.go
+++ b/models/plan_adquisicion.go
@@ -22,6 +22,29 @@ func ObtenerPlanAdquisicionByID(idstr string) (respuestaPlanAdquisicion map[stri
 	}
 }
 
+//ObtenerVersionesMongoByID regresa Versiones almacenadas en Mongo segun ID plan adquisicion
+func ObtenerVersionesMongoByID(idstr string) (respuestaVersionesMongo []map[string]interface{}, outputError interface{}) {
+	var versionesMongo []map[string]interface{}
+
+	mongoIDs := make([]map[string]interface{}, 0)
+	error := request.GetJson(beego.AppConfig.String("plan_adquicisiones_crud_url")+`Plan_adquisiciones_mongo/?query={"id":`+idstr+`}`, &versionesMongo)
+	if error != nil {
+		return nil, error
+	} else {
+		if versionesMongo[0]["Message"] == "Not found resource" {
+			error := "No existen versiones del plan adquisicion"
+			return nil, error
+		}
+		for index := range versionesMongo {
+			mongoID := make(map[string]interface{})
+			mongoID["_id"] = versionesMongo[index]["_id"]
+			mongoID["id"] = versionesMongo[index]["id"]
+			mongoIDs = append(mongoIDs, mongoID)
+		}
+		return mongoIDs, nil
+	}
+}
+
 //ActualizarPlanAdquisicion actualizar los campo Publicado de la tabla plan de adquisicion
 func ActualizarPlanAdquisicion(PlanAdquisicion map[string]interface{}, idStr string) (PlanAdquisionRespuesta map[string]interface{}, outputError interface{}) {
 	PlanAdquisicionPut := make(map[string]interface{})

--- a/routers/commentsRouter_controllers.go
+++ b/routers/commentsRouter_controllers.go
@@ -25,6 +25,15 @@ func init() {
             Filters: nil,
             Params: nil})
 
+    beego.GlobalControllerRouter["github.com/udistrital/plan_adquisiciones_mid/controllers:Plan_adquisicionController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_adquisiciones_mid/controllers:Plan_adquisicionController"],
+        beego.ControllerComments{
+            Method: "GetOne",
+            Router: "/versiones/:id",
+            AllowHTTPMethods: []string{"get"},
+            MethodParams: param.Make(),
+            Filters: nil,
+            Params: nil})
+
     beego.GlobalControllerRouter["github.com/udistrital/plan_adquisiciones_mid/controllers:Plan_adquisicion_por_fuentesController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_adquisiciones_mid/controllers:Plan_adquisicion_por_fuentesController"],
         beego.ControllerComments{
             Method: "GetAll",

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -15,6 +15,100 @@
     },
     "basePath": "/v1",
     "paths": {
+        "/PlanAdquisicion/versiones/{id}": {
+            "get": {
+                "tags": [
+                    "PlanAdquisicion"
+                ],
+                "description": "get Plan_adquisicionController by id",
+                "operationId": "Plan_adquisicionController.GetOne",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "description": "Id de un  plan de adquisicion",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/models.Plan_adquisicion"
+                        }
+                    },
+                    "403": {
+                        "description": ":id is empty"
+                    }
+                }
+            }
+        },
+        "/PlanAdquisicion/{id}": {
+            "put": {
+                "tags": [
+                    "PlanAdquisicion"
+                ],
+                "description": "update the Plan_adquisicion",
+                "operationId": "Plan_adquisicionController.Put",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "description": "ID del plan de adquisicion a actualizar",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "description": "body for Plan_adquisicion content",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.Plan_adquisicion"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/models.Plan_adquisicion"
+                        }
+                    },
+                    "403": {
+                        "description": ":id is not int"
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "PlanAdquisicion"
+                ],
+                "description": "create Plan_adquisicion",
+                "operationId": "Plan_adquisicionController.Create",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "description": "Id del registro de plan de adquisicion",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/models.Plan_adquisicion"
+                        }
+                    },
+                    "403": {
+                        "description": "body is empty"
+                    }
+                }
+            }
+        },
         "/RegistrosOrdenadoPorRubro/{planAdquisicionID}": {
             "get": {
                 "tags": [
@@ -418,6 +512,10 @@
         }
     },
     "definitions": {
+        "models.Plan_adquisicion": {
+            "title": "Plan_adquisicion",
+            "type": "object"
+        },
         "models.Plan_adquisicion_por_fuentes": {
             "title": "Plan_adquisicion_por_fuentes",
             "type": "object"
@@ -451,6 +549,10 @@
         {
             "name": "RegistrosPlanInversionActividadFuente",
             "description": "Registro_PlanInversion_ActividadFuente_financiamientoController operations for Registro_PlanInversion_ActividadFuente_financiamiento\n"
+        },
+        {
+            "name": "PlanAdquisicion",
+            "description": "Plan_adquisicionController operations for Plan_adquisicion\n"
         }
     ]
 }


### PR DESCRIPTION
…adquisicion #22

Se adiciona Endpoint para obtener las versiones almacenadas en mongo de un plan de adquisición. El endpoint es el siguiente:
http://localhost:4000/v1/PlanAdquisicion/versiones/:idPlanAdquisicion

el Json de respuesta tiene el siguiente formato:
```Json
{
  "Type": "OK",
  "Code": "200",
  "Body": [
    {
      "_id": "5fdb7baa86fc8cc01fc96086",
      "id": 6
    },
    {
      "_id": "5fdb7ed5986b84a9e369a386",
      "id": 6
    },
    {
      "_id": "5fdb86f43af186fdaee7cde6",
      "id": 6
    },
    {
      "_id": "5fdb8afc51063834bbaf8f6c",
      "id": 6
    },
    {
      "_id": "5fdb9a4051063834bbaf8f6d",
      "id": 6
    },
    {
      "_id": "5fdb9ea951063834bbaf8f6e",
      "id": 6
    },
    {
      "_id": "5fdb9fbd51063834bbaf8f6f",
      "id": 6
    }
  ]
}
```